### PR TITLE
adjusted review results output for Slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vscode
+.DS_Store

--- a/src/sidebars/ReviewSidebar.jsx
+++ b/src/sidebars/ReviewSidebar.jsx
@@ -93,88 +93,78 @@ const ReviewSidebar = () => {
                     (item) => item.isExceeds
                   );
 
-                  // correct header
-                  if (correct.length !== 0) {
-                    finalGradingReview.current += "You got these right:\n\n";
+                  // Correct Output
+                  if (correct.length || correctAndExceeds.length) {
+                    // correct header
+                    finalGradingReview.current += "*You got these right:*\n\n";
+
                     // correct meets output
-                    correct.map((item) => {
-                      finalGradingReview.current += `:meets: ${item.title}\n`;
-                    });
+                    if (correct.length) {
+                      correct.forEach((item) => {
+                        finalGradingReview.current += `:meets: ${item.title}\n`;
+                      });
+                    }
+
+                    // exceeds meets output
+                    if (correctAndExceeds.length) {
+                      correctAndExceeds.forEach((item) => {
+                        finalGradingReview.current += `:meets: :exceeds: *EXCEEDS:* ${item.title}\n`;
+                      });
+                    }
+                    // gap
                     finalGradingReview.current += "\n\n\n";
                   }
 
-                  // questioned header
-                  if (questioned.length !== 0) {
-                    finalGradingReview.current += "These need review:\n\n";
+                  // Questioned Output
+                  if (questioned.length || questionedAndExceeds.length) {
+                    // questioned header
+                    finalGradingReview.current +=
+                      "*These may need some adjustments:*\n\n";
+
                     // questioned output
-                    questioned.map((item) => {
-                      finalGradingReview.current += `:questioned: ${
-                        item.title
-                      }\n ${
-                        item.notes !== undefined ? `> ${item.notes}` : ""
-                      }\n`;
-                    });
+                    if (questioned.length) {
+                      questioned.forEach((item) => {
+                        finalGradingReview.current += `:questioned: ${
+                          item.title
+                        }\n${item.notes ? `> ${item.notes}\n\n` : ""}`;
+                      });
+                    }
+
+                    // questioned exceeds output
+                    if (questionedAndExceeds.length) {
+                      questionedAndExceeds.forEach((item) => {
+                        finalGradingReview.current += `:questioned: :exceeds: *EXCEEDS:* ${
+                          item.title
+                        }\n${item.notes ? `> ${item.notes}\n\n` : ""}`;
+                      });
+                    }
+                    // gap
                     finalGradingReview.current += "\n\n\n";
                   }
 
-                  if (wrong.length !== 0) {
+                  // Wrong Output
+                  if (wrong.length || wrongAndExceeds.length) {
+                    // wrong header
                     finalGradingReview.current +=
-                      "You'll need to go back and rework these:\n\n";
+                      "*These will need some work:*\n\n";
+
                     // wrong output
-                    wrong.map((item) => {
-                      finalGradingReview.current += `:needs-work: ${
-                        item.title
-                      }\n ${
-                        item.notes !== undefined ? `> ${item.notes}` : ""
-                      }\n`;
-                    });
-                    finalGradingReview.current += "\n\n\n";
-                  }
+                    if (wrong.length) {
+                      wrong.forEach((item) => {
+                        finalGradingReview.current += `:needs-work: ${
+                          item.title
+                        }\n${item.notes ? `> ${item.notes}\n\n` : ""}`;
+                      });
+                    }
 
-                  // exceeds
-
-                  if (
-                    correctAndExceeds.length !== 0 ||
-                    questionedAndExceeds.length !== 0 ||
-                    wrongAndExceeds.length !== 0
-                  ) {
-                    finalGradingReview.current +=
-                      "EXCEEDS EXPECTATIONS REQUIREMENTS:\n\n\n";
-                  }
-
-                  if (correctAndExceeds.length !== 0) {
-                    finalGradingReview.current +=
-                      "You got these Exceeds requirements right:\n\n";
-                    correctAndExceeds.map((item) => {
-                      finalGradingReview.current += `:meets: :exceeds: EXCEEDS: ${item.title}\n`;
-                      finalGradingReview.current += "\n\n\n";
-                    });
-                  }
-
-                  if (questionedAndExceeds.length !== 0) {
-                    finalGradingReview.current +=
-                      "These Exceeds requirements need review:\n\n";
-                    questionedAndExceeds.map((item) => {
-                      finalGradingReview.current += `:questioned: :exceeds: ${
-                        item.title
-                      }\n ${
-                        item.notes !== undefined ? `> ${item.notes}` : ""
-                      }\n`;
-                    });
-                    finalGradingReview.current += "\n\n\n";
-                  }
-
-                  if (wrongAndExceeds.length !== 0) {
-                    finalGradingReview.current +=
-                      "These Exceeds requirements need some work:\n\n";
-                    wrongAndExceeds.map((item) => {
-                      finalGradingReview.current += `:needs-work: :exceeds: ${
-                        item.title
-                      }\n ${
-                        item.notes !== undefined ? `> ${item.notes}` : ""
-                      }\n`;
-                    });
-                    finalGradingReview.current += "\n\n\n";
+                    // wrong exceeds output
+                    if (wrongAndExceeds.length) {
+                      wrongAndExceeds.forEach((item) => {
+                        finalGradingReview.current += `:needs-work: :exceeds: *EXCEEDS:* ${
+                          item.title
+                        }\n${item.notes ? `> ${item.notes}\n\n` : ""}`;
+                      });
+                    }
                   }
 
                   // copy contents of setfinalgradingreview to clipboard as text


### PR DESCRIPTION
- Combined both Meets & Exceeds results for each type (passed, questioned, failed) to save a bit of space. 
- Put each type in a "or" conditional block so the section's heading will render even if only Exceeds were marked in a type. This also allowed to combine the section ending's gap into one place.
- Changed the `.map()`s to `forEach`s as a returned array was not needed. 
- Fixed the extra space issue where if there were notes below a questioned / failed the `>` markdown wouldn't trigger in Slack.
- Reworded the headings a bit, added / remove new lines in various places to clean it up a bit. 
- Simplified the `.length !== 0` ternaries to check for a falsey value
- Added a gitignore. Was worried I would push a .ds_store or .vscode, hopefully that doesn't screw with anything. I didn't see one in there.