### PR TITLE
Media context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,6 @@ const App = () => {
   // techdegrees
   const [activeTechdegree, setActiveTechdegree] = useState(null);
   const [allTechdegrees, setAllTechdegrees] = useState([]); // NEW FOR TESTING (TA)
-  const [techdegreesLoaded, setTechdegreesLoaded] = useState(false);
   // projects
   const [allProjects, setAllProjects] = useState(null); // NEW FOR TESTING (TA)
   const [activeProject, setActiveProject] = useState(null);
@@ -130,8 +129,6 @@ const App = () => {
 
         // Store all projects
         setAllProjects(allProjects);
-
-        setTechdegreesLoaded(true);
       } catch (error) {
         console.error("Error fetching all data:", error);
       }
@@ -143,13 +140,8 @@ const App = () => {
   return (
     <AppState.Provider
       value={{
-        // theme
-        darkMode,
-        setDarkMode,
         // techdgrees & loading
         allTechdegrees,
-        techdegreesLoaded,
-        setTechdegreesLoaded,
         activeTechdegree,
         setActiveTechdegree,
         // projects
@@ -184,7 +176,7 @@ const App = () => {
     >
       <div className="h-screen w-full overflow-hidden bg-zinc-800 py-5 flex ">
         {activeOverlay && <Overlay />}
-        <MainSidebar />
+        <MainSidebar darkMode={darkMode} setDarkMode={setDarkMode} />
         <ViewContainer />
         <ReviewSidebar
           isSidebarOpen={reviewSidebarOpen}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,10 +27,8 @@ const App = () => {
   const [activeProjectIndex, setActiveProjectIndex] = useState(null);
   const [activeProjectQuestions, setActiveProjectQuestions] = useState(null);
   // project media
-  const [activeProjectMockups, setActiveProjectMockups] = useState([]);
   const [currentMockup, setCurrentMockup] = useState(null);
   const [activeOverlay, setActiveOverlay] = useState(false);
-  const [currentStudyGuide, setCurrentStudyGuide] = useState(null);
   // graded requirements
   const [gradedCorrect, setGradedCorrect] = useState([]);
   const [gradedQuestioned, setGradedQuestioned] = useState([]);
@@ -164,14 +162,10 @@ const App = () => {
         activeProjectQuestions,
         setActiveProjectQuestions,
         // project media
-        activeProjectMockups,
-        setActiveProjectMockups,
         activeOverlay,
         setActiveOverlay,
         currentMockup,
         setCurrentMockup,
-        currentStudyGuide,
-        setCurrentStudyGuide,
         // grading requirements
         gradedCorrect,
         setGradedCorrect,

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -3,8 +3,7 @@ import { AppState } from "../App";
 import ProgressBar from "./ProgressBar";
 
 const ProjectHeader = () => {
-  const { activeProject, activeTechdegree, allQuestions } =
-    useContext(AppState);
+  const { activeProject, activeTechdegree } = useContext(AppState);
 
   return (
     <div className="">

--- a/src/components/ProjectUtilityButtons.jsx
+++ b/src/components/ProjectUtilityButtons.jsx
@@ -2,8 +2,7 @@ import { useContext } from "react";
 import { AppState } from "../App";
 
 const ProjectUtilityButtons = () => {
-  const { excludeExceeds, setExcludeExceeds, activeTechdegree } =
-    useContext(AppState);
+  const { excludeExceeds, setExcludeExceeds } = useContext(AppState);
 
   return (
     <div className="px-5 py-8 flex items-center gap-2">

--- a/src/components/dropdowns/ProjectList.jsx
+++ b/src/components/dropdowns/ProjectList.jsx
@@ -13,8 +13,6 @@ const ProjectList = ({ setShowProjects }) => {
     activeProject,
     setActiveProject,
     setActiveProjectQuestions,
-    setActiveProjectMockups,
-    setCurrentStudyGuide,
     setGradedCorrect,
     setGradedQuestioned,
     setGradedWrong,
@@ -23,37 +21,7 @@ const ProjectList = ({ setShowProjects }) => {
 
   async function getActiveProjectData(project) {
     setActiveProjectQuestions(project.gradingSections);
-
-    // reset mockup state
-    setActiveProjectMockups([]);
-
-    setProjectMedia(project);
   }
-
-  // Set media for project
-  const setProjectMedia = (project) => {
-    // mobile mockups
-    project.mockups.mobile !== null &&
-      setActiveProjectMockups((prev) => [
-        ...prev,
-        { title: "Mobile", mock: project.mockups.mobile },
-      ]);
-
-    // tablet mockups
-    project.mockups.tablet !== null &&
-      setActiveProjectMockups((prev) => [
-        ...prev,
-        { title: "Tablet", mock: project.mockups.tablet },
-      ]);
-
-    // desktop mockups
-    project.mockups.desktop !== null &&
-      setActiveProjectMockups((prev) => [
-        ...prev,
-        { title: "Desktop", mock: project.mockups.desktop },
-      ]);
-    setCurrentStudyGuide(project.studyGuide || null);
-  };
 
   // Created a helper function for readability
   const resetProjectState = () => {

--- a/src/components/dropdowns/ProjectList.jsx
+++ b/src/components/dropdowns/ProjectList.jsx
@@ -4,7 +4,7 @@ import { AppState } from "../../App";
 import { FaRegFolder, FaRegFolderOpen } from "react-icons/fa";
 import { IoClose } from "react-icons/io5";
 
-const ProjectList = ({ setShowProjects }) => {
+const ProjectList = ({ setShowProjects, setSelectedProject }) => {
   const {
     activeProjectIndex,
     setActiveProjectIndex,
@@ -70,6 +70,7 @@ const ProjectList = ({ setShowProjects }) => {
                 resetProjectState();
                 setActiveProjectIndex(index);
                 setActiveProject(project);
+                setSelectedProject(project);
               }}
             >
               <div className="text-2xl">

--- a/src/components/dropdowns/project-media/ProjectMediaDropdown.jsx
+++ b/src/components/dropdowns/project-media/ProjectMediaDropdown.jsx
@@ -7,9 +7,8 @@ import { LuEye } from "react-icons/lu";
 import { SiReaddotcv } from "react-icons/si";
 import { AppState } from "../../../App";
 
-const ProjectMediaDropdown = () => {
-  const { activeProject, setCurrentMockup, setActiveOverlay } =
-    useContext(AppState);
+const ProjectMediaDropdown = ({ selectedProject }) => {
+  const { setCurrentMockup, setActiveOverlay } = useContext(AppState);
 
   const [openDropdown, setOpenDropdown] = useState(false);
   const [copyToClipboardAnimation, setCopyToClipboardAnimation] =
@@ -17,7 +16,7 @@ const ProjectMediaDropdown = () => {
 
   const copyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(activeProject.studyGuide);
+      await navigator.clipboard.writeText(selectedProject.studyGuide);
       setCopyToClipboardAnimation(true);
       setTimeout(() => {
         setCopyToClipboardAnimation(false);
@@ -29,8 +28,8 @@ const ProjectMediaDropdown = () => {
 
   // Convert mockups to an array
   let mockupArray;
-  if (activeProject) {
-    mockupArray = Object.entries(activeProject.mockups)
+  if (selectedProject) {
+    mockupArray = Object.entries(selectedProject.mockups)
       .map(([key, value]) => ({ type: key, mock: value })) // Convert to array of objects
       .filter((mockup) => mockup.mock !== null); // Only allow not-null values
   }
@@ -66,17 +65,19 @@ const ProjectMediaDropdown = () => {
           openDropdown ? "h-auto" : "h-[0px]"
         } w-full overflow-hidden`}
       >
-        {!activeProject && (
+        {!selectedProject && (
           <li className="py-5 text-center">No project selected</li>
         )}
 
-        {activeProject && !mockupArray.length && !activeProject.studyGuide && (
-          <li className="py-5 text-center">
-            There is no media for this project
-          </li>
-        )}
+        {selectedProject &&
+          !mockupArray.length &&
+          !selectedProject.studyGuide && (
+            <li className="py-5 text-center">
+              There is no media for this project
+            </li>
+          )}
 
-        {activeProject && mockupArray.length ? (
+        {selectedProject && mockupArray.length ? (
           mockupArray.map((mockup, index) => {
             return (
               <li
@@ -105,7 +106,7 @@ const ProjectMediaDropdown = () => {
           <></>
         )}
 
-        {activeProject?.studyGuide && (
+        {selectedProject?.studyGuide && (
           <li className="py-3 pl-[28px] pr-[258px] flex items-center justify-start hover:bg-white hover:bg-opacity-10 last-of-type:pb-4 duration-200">
             <div className="w-[30px] mr-5 text-2xl">
               <SiReaddotcv />
@@ -114,7 +115,7 @@ const ProjectMediaDropdown = () => {
             <div className="mr-5 min-w-[185px] w-[185px]">
               <p>Study Guide</p>
               <p className="text-xs text-zinc-500 shorten1">
-                {activeProject.studyGuide}
+                {selectedProject.studyGuide}
               </p>
             </div>
 
@@ -130,7 +131,7 @@ const ProjectMediaDropdown = () => {
               <a
                 className="text-[20px]"
                 target="_blank"
-                href={activeProject.studyGuide}
+                href={selectedProject.studyGuide}
                 title="open link in new window"
                 rel="noopener noreferrer" // Added for security when using target="_blank"
               >

--- a/src/components/dropdowns/project-media/ProjectMediaDropdown.jsx
+++ b/src/components/dropdowns/project-media/ProjectMediaDropdown.jsx
@@ -8,13 +8,8 @@ import { SiReaddotcv } from "react-icons/si";
 import { AppState } from "../../../App";
 
 const ProjectMediaDropdown = () => {
-  const {
-    activeProject,
-    activeProjectMockups,
-    setCurrentMockup,
-    setActiveOverlay,
-    currentStudyGuide,
-  } = useContext(AppState);
+  const { activeProject, setCurrentMockup, setActiveOverlay } =
+    useContext(AppState);
 
   const [openDropdown, setOpenDropdown] = useState(false);
   const [copyToClipboardAnimation, setCopyToClipboardAnimation] =
@@ -22,7 +17,7 @@ const ProjectMediaDropdown = () => {
 
   const copyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(currentStudyGuide);
+      await navigator.clipboard.writeText(activeProject.studyGuide);
       setCopyToClipboardAnimation(true);
       setTimeout(() => {
         setCopyToClipboardAnimation(false);
@@ -31,6 +26,15 @@ const ProjectMediaDropdown = () => {
       alert("Failed to copy: ", err);
     }
   };
+
+  // Convert mockups to an array
+  let mockupArray;
+  if (activeProject) {
+    mockupArray = Object.entries(activeProject.mockups)
+      .map(([key, value]) => ({ type: key, mock: value })) // Convert to array of objects
+      .filter((mockup) => mockup.mock !== null); // Only allow not-null values
+  }
+
   return (
     <div className="w-full rounded-2xl bg-zinc-950 hover:bg-zinc-900 cursor-pointer duration-200 overflow-hidden">
       {/* dropdown header */}
@@ -45,7 +49,7 @@ const ProjectMediaDropdown = () => {
         </div>
         <div>
           <p className="font-bold">Project Media</p>
-          <p className="text-sm opacity-50">Mockups and studyguides</p>
+          <p className="text-sm opacity-50">Mockups and Study Guides</p>
         </div>
         <button
           className={`${
@@ -62,35 +66,33 @@ const ProjectMediaDropdown = () => {
           openDropdown ? "h-auto" : "h-[0px]"
         } w-full overflow-hidden`}
       >
-        {activeProject === null && (
+        {!activeProject && (
           <li className="py-5 text-center">No project selected</li>
         )}
 
-        {activeProject !== null &&
-          activeProjectMockups.length === 0 &&
-          currentStudyGuide === null && (
-            <li className="py-5 text-center">
-              There is no media for this project
-            </li>
-          )}
+        {activeProject && !mockupArray.length && !activeProject.studyGuide && (
+          <li className="py-5 text-center">
+            There is no media for this project
+          </li>
+        )}
 
-        {activeProjectMockups.length !== 0 &&
-          activeProjectMockups.map((mock, index) => {
+        {activeProject && mockupArray.length ? (
+          mockupArray.map((mockup, index) => {
             return (
               <li
                 onClick={() => {
-                  setCurrentMockup(mock.mock);
+                  setCurrentMockup(mockup.mock);
                   setActiveOverlay(true);
                 }}
                 className="px-8 py-3 pl-[28px] flex items-center justify-start hover:bg-white hover:bg-opacity-10 last-of-type:pb-4 duration-200"
                 key={index}
               >
-                {mock.mock !== null && (
+                {mockup.mock !== null && (
                   <p className="flex justify-between items-center w-full">
                     <span className="text-2xl mr-5">
                       <IoIosImages />
                     </span>
-                    {`${mock.title} mockup`}
+                    {`${mockup.type} mockup`}
                     <button className="ml-auto">
                       <LuEye />
                     </button>
@@ -98,20 +100,21 @@ const ProjectMediaDropdown = () => {
                 )}
               </li>
             );
-          })}
+          })
+        ) : (
+          <></>
+        )}
 
-        {currentStudyGuide !== null && (
+        {activeProject?.studyGuide && (
           <li className="py-3 pl-[28px] pr-[258px] flex items-center justify-start hover:bg-white hover:bg-opacity-10 last-of-type:pb-4 duration-200">
-            {/* study guide icon */}
             <div className="w-[30px] mr-5 text-2xl">
               <SiReaddotcv />
             </div>
 
-            {/* study guide text */}
             <div className="mr-5 min-w-[185px] w-[185px]">
               <p>Study Guide</p>
               <p className="text-xs text-zinc-500 shorten1">
-                {currentStudyGuide}
+                {activeProject.studyGuide}
               </p>
             </div>
 
@@ -127,7 +130,7 @@ const ProjectMediaDropdown = () => {
               <a
                 className="text-[20px]"
                 target="_blank"
-                href={currentStudyGuide}
+                href={activeProject.studyGuide}
                 title="open link in new window"
                 rel="noopener noreferrer" // Added for security when using target="_blank"
               >

--- a/src/components/dropdowns/techdegrees/TechdegreeDropdown.jsx
+++ b/src/components/dropdowns/techdegrees/TechdegreeDropdown.jsx
@@ -13,8 +13,6 @@ const TechdegreeDropdown = ({ setShowProjects }) => {
     setActiveProjectIndex,
     activeProject,
     setActiveProject,
-    setActiveProjectMockups,
-    setCurrentStudyGuide,
   } = useContext(AppState);
 
   const [openDropdown, setOpenDropdown] = useState(false);
@@ -24,8 +22,6 @@ const TechdegreeDropdown = ({ setShowProjects }) => {
     setShowProjects(false);
     setActiveProjectIndex(null);
     setActiveProject(null);
-    setActiveProjectMockups([]);
-    setCurrentStudyGuide(null);
   };
 
   return (

--- a/src/sidebars/MainSidebar.jsx
+++ b/src/sidebars/MainSidebar.jsx
@@ -13,6 +13,7 @@ import TechdegreeDropdown from "../components/dropdowns/techdegrees/TechdegreeDr
 const MainSidebar = ({ darkMode, setDarkMode }) => {
   const [mainSidebarOpen, setMainSidebarOpen] = useState(true);
   const [showProjects, setShowProjects] = useState(false);
+  const [selectedProject, setSelectedProject] = useState(null);
 
   const { activeProject, setActiveTechdegree, activeTechdegree } =
     useContext(AppState);
@@ -69,11 +70,14 @@ const MainSidebar = ({ darkMode, setDarkMode }) => {
           <TechdegreeDropdown setShowProjects={setShowProjects} />
 
           {showProjects && activeTechdegree && (
-            <ProjectList setShowProjects={setShowProjects} />
+            <ProjectList
+              setShowProjects={setShowProjects}
+              setSelectedProject={setSelectedProject}
+            />
           )}
 
           <LinksDropdown />
-          <ProjectMediaDropdown />
+          <ProjectMediaDropdown selectedProject={selectedProject} />
         </div>
       )}
       <div

--- a/src/sidebars/MainSidebar.jsx
+++ b/src/sidebars/MainSidebar.jsx
@@ -10,17 +10,12 @@ import LinksDropdown from "../components/dropdowns/links/LinksDropdown";
 import ProjectMediaDropdown from "../components/dropdowns/project-media/ProjectMediaDropdown";
 import TechdegreeDropdown from "../components/dropdowns/techdegrees/TechdegreeDropdown";
 
-const MainSidebar = () => {
+const MainSidebar = ({ darkMode, setDarkMode }) => {
   const [mainSidebarOpen, setMainSidebarOpen] = useState(true);
   const [showProjects, setShowProjects] = useState(false);
 
-  const {
-    darkMode,
-    setDarkMode,
-    activeProject,
-    setActiveTechdegree,
-    activeTechdegree,
-  } = useContext(AppState);
+  const { activeProject, setActiveTechdegree, activeTechdegree } =
+    useContext(AppState);
 
   const handleSidebarToggles = (event) => {
     if (event.altKey && event.code === "KeyE") {


### PR DESCRIPTION
- Removed `techdegreesLoaded` state as it wasn't being used.
- Removed `activeProjectMockups` and `activeStudyGuide` states and moved it to props being passed from the selected project via `MainSidebar.jsx`
- Created a `selectedProject` state in `MainSidebar.jsx` as a start of trying to relieve the need for `activeProject` context.
- Removed `darkMode` from context as `MainSidebar.jsx` was the only component using it. May need to add it back if Rohald's cmdk stuff uses it. 